### PR TITLE
feat: Add graceful shutdown on druid components

### DIFF
--- a/source/lib/config/user_data/data_user_data
+++ b/source/lib/config/user_data/data_user_data
@@ -59,6 +59,7 @@ user=${USER_NAME}
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/historical.log
+stopwaitsecs=30
 EOF
 
 chown -R ${USER_NAME}:${USER_NAME} /home/${USER_NAME}/ /mnt/disk2

--- a/source/lib/config/user_data/historical_user_data
+++ b/source/lib/config/user_data/historical_user_data
@@ -47,6 +47,7 @@ user=${USER_NAME}
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/historical.log
+stopwaitsecs=30
 EOF
 
 chown -R ${USER_NAME}:${USER_NAME} /home/${USER_NAME}/ /mnt/disk2

--- a/source/lib/config/user_data/master_user_data
+++ b/source/lib/config/user_data/master_user_data
@@ -32,6 +32,7 @@ user=${USER_NAME}
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/coordinator.log
+stopwaitsecs=30
 EOF
 
 # change ownership of ${USER_NAME} home directory

--- a/source/lib/config/user_data/middleManager_user_data
+++ b/source/lib/config/user_data/middleManager_user_data
@@ -38,6 +38,7 @@ user=${USER_NAME}
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/middleManager.log
+stopwaitsecs=30
 EOF
 
 # change ownership of ${USER_NAME} home directory

--- a/source/lib/config/user_data/query_user_data
+++ b/source/lib/config/user_data/query_user_data
@@ -27,6 +27,7 @@ user=${USER_NAME}
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/broker.log
+stopwaitsecs=30
 EOF
 
 cat <<EOF > $DRUID_HOME/conf/supervisor/supervisord.d/router.conf

--- a/source/lib/uploads/scripts/druid/terminate_druid_node.sh
+++ b/source/lib/uploads/scripts/druid/terminate_druid_node.sh
@@ -109,6 +109,8 @@ waitForProcess() {
         else
             echo "The new node is up. Stopping old node..."
             $SUPERVISORCTL_CMD stop $process_name
+            # wait gracefulShutdownTimeout for 30 seconds
+            sleep 30
             break
         fi
     done


### PR DESCRIPTION
Description of changes:

Sometimes we can observe after stopping historical the host gets terminated immediately, this causes the in-flight requests to fail and results in 500s.

This PR adds a 30s sleep after the historical/query/master stop, so it has enough time to gracefully shutdown the process before terminating the host. Also updates the supervisord config to wait for 30s before sending the KILL signal.

I chose 30s because the default druid.server.http.gracefulShutdownTimeout is PT30s (https://druid.apache.org/docs/latest/configuration/#historical-query-configs)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.