### PR TITLE
Lower Zookeeper Timout

### DIFF
--- a/source/lib/uploads/config/_common/common.runtime.properties
+++ b/source/lib/uploads/config/_common/common.runtime.properties
@@ -53,8 +53,8 @@ druid.startup.logging.logProperties=true
 
 druid.zk.service.host={{zookeeper_ips}}
 druid.zk.paths.base=/druid
-druid.zk.service.sessionTimeoutMs=3600000
-druid.zk.service.connectionTimeoutMs=3600000
+druid.zk.service.sessionTimeoutMs=40000
+druid.zk.service.connectionTimeoutMs=30000
 
 #
 # Metadata storage


### PR DESCRIPTION
When a Zookeeper (ZK) session times out, the node becomes unavailable to other services. It’s important to keep the session timeout relatively low (40 seconds is reasonable). If the timeout is set too high, services attempting to connect during a failure will wait too long, resulting in delayed failure detection.

On the other hand, the ZK connection timeout defines how long the client waits before attempting to reconnect to Zookeeper in the event of transient network issues. If a request fails to reach Zookeeper, the client will retry within this timeout period. 

If the connection timeout is shorter than the session timeout, the client has a chance to reconnect and preserve the session. However, if both timeouts are set to the same value, every connection issue will result in session invalidation, leading to the negative consequences previously mentioned. It’s thus considered best practice to avoid this scenario by properly configuring timeouts.