### PR TITLE
Locate where root disk is mounted before mounting other data disks

### DIFF
--- a/source/lib/config/user_data/data_user_data
+++ b/source/lib/config/user_data/data_user_data
@@ -3,8 +3,11 @@ HISTORICAL_CONFIG_VERSION={{HISTORICAL_CONFIG_VERSION}}
 MIDDLEMANAGER_CONFIG_VERSION={{MIDDLEMANAGER_CONFIG_VERSION}}
 
 echo " >>druid>> mounting NVME disks $(date)"
+# Detect the root partition to avoid formatting the OS disk
+root_src="$(findmnt -n -o SOURCE /)"
+root_disk="/dev/$(lsblk -no PKNAME "$root_src")"
 PATH_INDEX=2
-for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
+for NVME_PATH in $(nvme list -o json | jq --arg root "$root_disk" '.Devices | map(select(.DevicePath != $root).DevicePath) | sort | join(" ")' | tr -d '"')
 do
     MOUNT_POINT=/mnt/disk${PATH_INDEX}
     mkdir -p $MOUNT_POINT

--- a/source/lib/config/user_data/historical_user_data
+++ b/source/lib/config/user_data/historical_user_data
@@ -2,8 +2,11 @@
 HISTORICAL_CONFIG_VERSION={{HISTORICAL_CONFIG_VERSION}}
 
 echo " >>druid>> mounting NVME disks $(date)"
+# Detect the root partition to avoid formatting the OS disk
+root_src="$(findmnt -n -o SOURCE /)"
+root_disk="/dev/$(lsblk -no PKNAME "$root_src")"
 PATH_INDEX=2
-for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
+for NVME_PATH in $(nvme list -o json | jq --arg root "$root_disk" '.Devices | map(select(.DevicePath != $root).DevicePath) | sort | join(" ")' | tr -d '"')
 do
     MOUNT_POINT=/mnt/disk${PATH_INDEX}
     mkdir -p $MOUNT_POINT

--- a/source/lib/config/user_data/middleManager_user_data
+++ b/source/lib/config/user_data/middleManager_user_data
@@ -2,8 +2,11 @@
 MIDDLEMANAGER_CONFIG_VERSION={{MIDDLEMANAGER_CONFIG_VERSION}}
 
 echo " >>druid>> mounting NVME disks $(date)"
+# Detect the root partition to avoid formatting the OS disk
+root_src="$(findmnt -n -o SOURCE /)"
+root_disk="/dev/$(lsblk -no PKNAME "$root_src")"
 PATH_INDEX=2
-for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
+for NVME_PATH in $(nvme list -o json | jq --arg root "$root_disk" '.Devices | map(select(.DevicePath != $root).DevicePath) | sort | join(" ")' | tr -d '"')
 do
     MOUNT_POINT=/mnt/disk${PATH_INDEX}
     mkdir -p $MOUNT_POINT


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
Mounting (connects a storage device to a directory in the file system so you can access it) is done by deployment scripts (`data_user_data`, `historical_user_data`, and `middleManager_user_data`), which is non-deterministic. The original code assumes that the root partition is mounted under `/dev/nvme0n1`, which is not always the case as it can be under any disk. This PR fixed the problem by having all deployment scripts detect the root partition properly before mounting the other data disks.

Deepbi discussion: https://atlassian.slack.com/archives/C070ALB9JNS/p1765975125875219?thread_ts=1765315841.256709&cid=C070ALB9JNS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
