### PR TITLE
Ensure that all the load balancer's listeners are supporting complian…

### DIFF
--- a/source/lib/constructs/druidEksBase.ts
+++ b/source/lib/constructs/druidEksBase.ts
@@ -420,7 +420,7 @@ export abstract class DruidEksBase extends Construct {
             alb_scheme: this.props.druidClusterParams.internetFacing
                 ? 'internet-facing'
                 : 'internal',
-            alb_ssl_policy: elb.SslPolicy.RECOMMENDED_TLS,
+            alb_ssl_policy: elb.SslPolicy.TLS12,
             alb_tags: Object.entries({
                 ...this.props.solutionTags,
                 ...(this.props.druidClusterParams.enableFipsEndpoints && {

--- a/source/lib/constructs/druidEksBase.ts
+++ b/source/lib/constructs/druidEksBase.ts
@@ -420,7 +420,7 @@ export abstract class DruidEksBase extends Construct {
             alb_scheme: this.props.druidClusterParams.internetFacing
                 ? 'internet-facing'
                 : 'internal',
-            alb_ssl_policy: elb.SslPolicy.TLS12,
+            alb_ssl_policy: elb.SslPolicy.RECOMMENDED_TLS,
             alb_tags: Object.entries({
                 ...this.props.solutionTags,
                 ...(this.props.druidClusterParams.enableFipsEndpoints && {

--- a/source/lib/constructs/druidEksBase.ts
+++ b/source/lib/constructs/druidEksBase.ts
@@ -420,7 +420,9 @@ export abstract class DruidEksBase extends Construct {
             alb_scheme: this.props.druidClusterParams.internetFacing
                 ? 'internet-facing'
                 : 'internal',
-            alb_ssl_policy: elb.SslPolicy.RECOMMENDED_TLS,
+            alb_ssl_policy: this.props.druidClusterParams.enableFipsEndpoints
+                ? elb.SslPolicy.FIPS_TLS13_12 // FIPS-compliant policy required for FedRAMP compliance (ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04)
+                : elb.SslPolicy.RECOMMENDED_TLS,
             alb_tags: Object.entries({
                 ...this.props.solutionTags,
                 ...(this.props.druidClusterParams.enableFipsEndpoints && {

--- a/source/lib/constructs/druidEksBase.ts
+++ b/source/lib/constructs/druidEksBase.ts
@@ -420,9 +420,7 @@ export abstract class DruidEksBase extends Construct {
             alb_scheme: this.props.druidClusterParams.internetFacing
                 ? 'internet-facing'
                 : 'internal',
-            alb_ssl_policy: this.props.druidClusterParams.enableFipsEndpoints
-                ? elb.SslPolicy.TLS12
-                : elb.SslPolicy.RECOMMENDED_TLS,
+            alb_ssl_policy: elb.SslPolicy.RECOMMENDED_TLS,
             alb_tags: Object.entries({
                 ...this.props.solutionTags,
                 ...(this.props.druidClusterParams.enableFipsEndpoints && {

--- a/source/lib/stacks/druidEc2Stack.ts
+++ b/source/lib/stacks/druidEc2Stack.ts
@@ -777,8 +777,9 @@ export class DruidEc2Stack extends DruidStack {
                 port: 443,
                 certificates: [this.certificate],
                 defaultAction: elb.ListenerAction.forward([targetGrp]),
-                // https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_elasticloadbalancingv2/SslPolicy.html#aws_cdk.aws_elasticloadbalancingv2.SslPolicy.RECOMMENDED_TLS
-                sslPolicy: elb.SslPolicy.RECOMMENDED_TLS,
+                sslPolicy: this.props.clusterParams.enableFipsEndpoints
+                    ? elb.SslPolicy.FIPS_TLS13_12 // FIPS-compliant policy required for FedRAMP compliance (ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04)
+                    : elb.SslPolicy.RECOMMENDED_TLS,
             });
         } else {
             loadbalancer.addListener(`listener-http-id`, {

--- a/source/lib/stacks/druidEc2Stack.ts
+++ b/source/lib/stacks/druidEc2Stack.ts
@@ -777,7 +777,7 @@ export class DruidEc2Stack extends DruidStack {
                 port: 443,
                 certificates: [this.certificate],
                 defaultAction: elb.ListenerAction.forward([targetGrp]),
-                sslPolicy: elb.SslPolicy.RECOMMENDED_TLS,
+                sslPolicy: elb.SslPolicy.TLS12,
             });
         } else {
             loadbalancer.addListener(`listener-http-id`, {

--- a/source/lib/stacks/druidEc2Stack.ts
+++ b/source/lib/stacks/druidEc2Stack.ts
@@ -777,7 +777,8 @@ export class DruidEc2Stack extends DruidStack {
                 port: 443,
                 certificates: [this.certificate],
                 defaultAction: elb.ListenerAction.forward([targetGrp]),
-                sslPolicy: elb.SslPolicy.TLS12,
+                // https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_elasticloadbalancingv2/SslPolicy.html#aws_cdk.aws_elasticloadbalancingv2.SslPolicy.RECOMMENDED_TLS
+                sslPolicy: elb.SslPolicy.RECOMMENDED_TLS,
             });
         } else {
             loadbalancer.addListener(`listener-http-id`, {

--- a/source/lib/stacks/druidEc2Stack.ts
+++ b/source/lib/stacks/druidEc2Stack.ts
@@ -777,9 +777,7 @@ export class DruidEc2Stack extends DruidStack {
                 port: 443,
                 certificates: [this.certificate],
                 defaultAction: elb.ListenerAction.forward([targetGrp]),
-                sslPolicy: this.props.clusterParams.enableFipsEndpoints
-                    ? elb.SslPolicy.TLS12 // fall back to 1.2 for FIPS enabled ALB as 1.3 is yet to be supported
-                    : elb.SslPolicy.RECOMMENDED_TLS,
+                sslPolicy: elb.SslPolicy.RECOMMENDED_TLS,
             });
         } else {
             loadbalancer.addListener(`listener-http-id`, {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
FedRAMP violation found that AWS ELB resources are not supporting compliant TLS termination. Based on the [ar-evaluator](https://bitbucket.org/atlassian/ar-evaluator/src/main/src/controls/epm/elbSecureListener/queries/batch.sql), listeners are non-compliant if they:
- use an SSL policy other than `ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04`
- use the HTTP protocol (instead of HTTPS) AND has forward actions configured

If `enableFipsEndpoints` is enabled (federal), we want to change the ssl policy to be set to`elb.SslPolicy.FIPS_TLS13_12` based on enums.ts in [aws-cdk](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-elasticloadbalancingv2/lib/shared/enums.ts#L162).

Resources:
- [Slack Thread](https://atlassian.slack.com/archives/C02H23XU943/p1752648480988739)
- [Jira Ticket](https://hello.jira.atlassian.cloud/jira/software/projects/ACT/list?jql=project%20%3D%20ACT%0AAND%20textfields%20~%20%22Ensure%20that%20all%20the%20load%20balancer%27s%20listeners%20are%20supporting%20compliant%20TLS%20termination*%22%0AORDER%20BY%20created%20DESC&selectedIssue=ACT-2699)
- [FIPS Security Policies](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#fips-security-policies)
- [SSL Policy](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancingv2.SslPolicy.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
