### PR TITLE
Revert "Locate where root disk is mounted before mounting other data disks"

### DIFF
--- a/source/lib/config/user_data/data_user_data
+++ b/source/lib/config/user_data/data_user_data
@@ -3,11 +3,8 @@ HISTORICAL_CONFIG_VERSION={{HISTORICAL_CONFIG_VERSION}}
 MIDDLEMANAGER_CONFIG_VERSION={{MIDDLEMANAGER_CONFIG_VERSION}}
 
 echo " >>druid>> mounting NVME disks $(date)"
-# Detect the root partition to avoid formatting the OS disk
-root_src="$(findmnt -n -o SOURCE /)"
-root_disk="/dev/$(lsblk -no PKNAME "$root_src")"
 PATH_INDEX=2
-for NVME_PATH in $(nvme list -o json | jq --arg root "$root_disk" '.Devices | map(select(.DevicePath != $root).DevicePath) | sort | join(" ")' | tr -d '"')
+for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
 do
     MOUNT_POINT=/mnt/disk${PATH_INDEX}
     mkdir -p $MOUNT_POINT

--- a/source/lib/config/user_data/historical_user_data
+++ b/source/lib/config/user_data/historical_user_data
@@ -2,11 +2,8 @@
 HISTORICAL_CONFIG_VERSION={{HISTORICAL_CONFIG_VERSION}}
 
 echo " >>druid>> mounting NVME disks $(date)"
-# Detect the root partition to avoid formatting the OS disk
-root_src="$(findmnt -n -o SOURCE /)"
-root_disk="/dev/$(lsblk -no PKNAME "$root_src")"
 PATH_INDEX=2
-for NVME_PATH in $(nvme list -o json | jq --arg root "$root_disk" '.Devices | map(select(.DevicePath != $root).DevicePath) | sort | join(" ")' | tr -d '"')
+for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
 do
     MOUNT_POINT=/mnt/disk${PATH_INDEX}
     mkdir -p $MOUNT_POINT

--- a/source/lib/config/user_data/middleManager_user_data
+++ b/source/lib/config/user_data/middleManager_user_data
@@ -2,11 +2,8 @@
 MIDDLEMANAGER_CONFIG_VERSION={{MIDDLEMANAGER_CONFIG_VERSION}}
 
 echo " >>druid>> mounting NVME disks $(date)"
-# Detect the root partition to avoid formatting the OS disk
-root_src="$(findmnt -n -o SOURCE /)"
-root_disk="/dev/$(lsblk -no PKNAME "$root_src")"
 PATH_INDEX=2
-for NVME_PATH in $(nvme list -o json | jq --arg root "$root_disk" '.Devices | map(select(.DevicePath != $root).DevicePath) | sort | join(" ")' | tr -d '"')
+for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
 do
     MOUNT_POINT=/mnt/disk${PATH_INDEX}
     mkdir -p $MOUNT_POINT


### PR DESCRIPTION
Reverts jshi-atlas/scalable-analytics-using-apache-druid-on-aws#56, need to branch off of correct tag.